### PR TITLE
Fix comment hierarchy bug in parser

### DIFF
--- a/otui_editor_pro.py
+++ b/otui_editor_pro.py
@@ -44,7 +44,7 @@ class OTUIParser:
                 while stack and d <= stack[-1].depth: stack.pop()
                 node = OTUINode("//", stripped[2:].strip(), d, [])
                 stack[-1].children.append(node)
-                stack.append(node)
+                # comentários não devem formar hierarquia; não empilha
                 continue
             d = depth_of(raw_line, stripped)
             while stack and d <= stack[-1].depth: stack.pop()


### PR DESCRIPTION
## Summary
- prevent comment lines from capturing child nodes during parsing

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68992a9f89f8832e81c7d725526b5b65